### PR TITLE
specific buttons should not be changed by editing css for common buttons

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -2,22 +2,24 @@
   width: 40%;
   margin: 10px;
   font-size: 9px;
-   background-color: $primary;
+   // background-color: $primary;
   // max-width: 220px
 }
 
 .product-button-holder{
-    .btn-default {
-    background-color: $primary-white;
-    border-color: $primary-dark;
-    border-radius: 4px;
-  }
-    .btn-default:hover {
-      color: $primary-lighter;
-      background-color: $primary-dark;
-      border-width: 1px;
-      border-color: $primary-dark;
-  }
+
+  // should not be necessary to reset the default button to actually be default.
+  //   .btn-default {
+  //   background-color: $primary-white;
+  //   border-color: $primary-dark;
+  //   border-radius: 4px;
+  // }
+  //   .btn-default:hover {
+  //     color: $primary-lighter;
+  //     background-color: $primary-dark;
+  //     border-width: 1px;
+  //     border-color: $primary-dark;
+  // }
 }
 
 

--- a/app/assets/stylesheets/components/_card_user.scss
+++ b/app/assets/stylesheets/components/_card_user.scss
@@ -112,21 +112,35 @@
   text-align: center;
   margin: 0px;
 
-  .btn {
-    background-color: $primary;
-    border-width: 0px;
-    border-color: transparent;
-    border-radius: 4px;
-    width: 50px;
-    height: 45px;
-  }
-    .btn:hover {
-      color: $primary-lighter;
-      background-color: #ca4216;
-      border-width: 1px;
-      border-color: #ca4216;
-  }
+//btn is the bootstrap type for ALL buttons. Bad idea to make general changes
+//to it for a single component, particular concerning width (overflows) or color. Global changes can be set in variables and bootstrap_variables
+//files
+// to make changes to specifiic buttons, create a class for those buttons.
+// i'm getting rid of this because the buttons in lend have different border radiuses
+  // .btn {
+  //   background-color: $primary;
+  //   border-width: 0px;
+  //   border-color: transparent;
+  //   border-radius: 4px;
+  //   width: 50px;
+  //   height: 45px;
+  // }
+  //   .btn:hover {
+  //     color: $primary-lighter;
+  //     background-color: #ca4216;
+  //     border-width: 1px;
+  //     border-color: #ca4216;
+  // }
 }
+
+.btn-small {
+  width: 50px;
+  height: 45px;
+  border-width: 0px;
+  border-color: transparent;
+  border-radius: 4px;
+}
+
 
 
 .product-controls a {

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -21,7 +21,7 @@
   <%= f.input :photo %>
   <%= f.input :photo_cache, as: :hidden %>
 
-  <%= f.button :submit %>
+  <%= f.button :submit, class: "btn btn-primary" %>
 <% end %>
 
 </div>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -33,7 +33,7 @@
 
           <div class="text-center add-margin product-controls text-modif">
             <%= link_to "Go!", request_book_path(@book),
-            {class: "btn btn-primary", :method => :post} %>
+            {class: "btn btn-primary btn-small", :method => :post} %>
           </div>
 
         </div>


### PR DESCRIPTION
- bootstrap global button .btn should not be edited to have specific width or colour.
  in case global edits need to be made, they should first be made by editing the variables.scss or bootstrap_variables.scss file.
- unnecessary to set $primary to button class used to set width of button, simply add the class btn-primary to the list of classes instead.
